### PR TITLE
feat: provide option to skip version validation for some packages during release-finish/hotfix-finish

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,14 +62,28 @@ Creates a release branch from develop and optionally sets version. If a version 
 [Dist-tag](https://docs.npmjs.com/adding-dist-tags-to-packages) dependencies to `dev` tag are replaced to `next` dist-tag dependencies in `package.json` file. 
 
 Lock file is not updated in development branches to reduce merge conflicts (assumed to be auto-update by CI or updated manually locally for development branches).
-### `release-finish`
-Merges release branch to main and back to develop
+### `release-finish [--no-version-check <package1> [<package2> ...]]`
+Merges release branch to main and back to develop.
+
+The `--no-version-check` argument allows you to specify a list of packages that should be excluded from version validation. This is useful for packages that follow eternal alpha/beta approach (e.g. '@mui/lab'). If specified, at least one package must be provided.
+
+Example:
+```shell
+npx release-finish --no-version-check @mui/lab
+```
 
 ## Hotfix Commands
 ### `hotfix-start`
 Creates a hotfix branch from main and increments the patch version
-### `hotfix-finish`
-Merges hotfix branch to main and back to develop
+### `hotfix-finish [--no-version-check <package1> [<package2> ...]]`
+Merges hotfix branch to main and back to develop.
+
+The `--no-version-check` argument allows you to specify a list of packages that should be excluded from version validation. This is useful for packages that follow eternal alpha/beta approach (e.g. '@mui/lab'). If specified, at least one package must be provided.
+
+Example:
+```shell
+npx hotfix-finish --no-version-check @mui/lab
+```
 
 ## Lock File Utilities
 ### `update-lock-file <scope>`

--- a/bin/hotfix-finish.js
+++ b/bin/hotfix-finish.js
@@ -16,7 +16,31 @@
  */
 
 const git = require('simple-git')();
+const commandLineArgs = require('command-line-args');
 const { finishReleaseBranch } = require('../lib/release-branch-scripts');
 
+// Define command line options
+const optionDefinitions = [
+    {
+        name: 'no-version-check',
+        type: String,
+        multiple: true,
+        defaultValue: [],
+        description: 'List of packages to exclude from version validation'
+    }
+];
+
+// Parse command line arguments
+const options = commandLineArgs(optionDefinitions);
+
+// Validate that if --no-version-check is specified, it must have at least one package
+if (process.argv.includes('--no-version-check') && options['no-version-check'].length === 0) {
+    console.error('Error: --no-version-check flag requires at least one package to be specified');
+    process.exit(1);
+}
+
+// Convert array of packages to Set
+const packagesToExcludeFromVersionValidation = new Set(options['no-version-check']);
+
 // Execute the hotfix finish workflow
-finishReleaseBranch(git, 'hotfix'); 
+finishReleaseBranch(git, 'hotfix', packagesToExcludeFromVersionValidation); 

--- a/bin/release-finish.js
+++ b/bin/release-finish.js
@@ -16,7 +16,31 @@
  */
 
 const git = require('simple-git')();
+const commandLineArgs = require('command-line-args');
 const { finishReleaseBranch } = require('../lib/release-branch-scripts');
 
+// Define command line options
+const optionDefinitions = [
+    {
+        name: 'no-version-check',
+        type: String,
+        multiple: true,
+        defaultValue: [],
+        description: 'List of packages to exclude from version validation'
+    }
+];
+
+// Parse command line arguments
+const options = commandLineArgs(optionDefinitions);
+
+// Validate that if --no-version-check is specified, it must have at least one package
+if (process.argv.includes('--no-version-check') && options['no-version-check'].length === 0) {
+    console.error('Error: --no-version-check flag requires at least one package to be specified');
+    process.exit(1);
+}
+
+// Convert array of packages to Set
+const packagesToExcludeFromVersionValidation = new Set(options['no-version-check']);
+
 // Execute the release finish workflow
-finishReleaseBranch(git, 'release');
+finishReleaseBranch(git, 'release', packagesToExcludeFromVersionValidation);

--- a/lib/release-branch-scripts.js
+++ b/lib/release-branch-scripts.js
@@ -42,16 +42,17 @@ const { validateDependencies } = require('./validate-dependencies');
  * 
  * @param {Object} git - The simple-git instance
  * @param {string} branchName - The name of release branch ('release' or 'hotfix')
+ * @param {Set<string>} packagesToExcludeFromVersionValidation - Set of package names to exclude from version validation
  * @returns {Promise<void>} A promise that resolves when the branch workflow is complete
  */
-function finishReleaseBranch(git, branchName) {
+function finishReleaseBranch(git, branchName, packagesToExcludeFromVersionValidation = new Set()) {
     const isLernaProject = fs.existsSync("./lerna.json");
     let branchVersion;
     let sourceBranch;
 
     return checkUncommittedChanges(git)
         .then(() => switchToBranchAndPull(git, branchName))
-        .then(() => validateDependencies('main', new Set(['@mui/lab'])))
+        .then(() => validateDependencies('main', packagesToExcludeFromVersionValidation))
         .then(() => {
             // Get version in branch
             return getVersionFromBranch(git, branchName, isLernaProject)

--- a/lib/release-branch-scripts.js
+++ b/lib/release-branch-scripts.js
@@ -51,7 +51,7 @@ function finishReleaseBranch(git, branchName) {
 
     return checkUncommittedChanges(git)
         .then(() => switchToBranchAndPull(git, branchName))
-        .then(() => validateDependencies('main'))
+        .then(() => validateDependencies('main', new Set(['@mui/lab'])))
         .then(() => {
             // Get version in branch
             return getVersionFromBranch(git, branchName, isLernaProject)

--- a/lib/validate-dependencies.js
+++ b/lib/validate-dependencies.js
@@ -23,9 +23,10 @@ const { handleError } = require('./git-utils');
  * Validates that all dependencies are using versions allowed for the specific branch type
  * 
  * @param {string} targetBranchType - The type of branch ('main', 'release', 'hotfix', 'develop', 'feature', 'bugfix')
+ * @param {Set<string>} excludePackages - Set of package names to exclude from validation
  * @returns {Promise<void>} A promise that resolves when validation is complete
  */
-function validateDependencies(targetBranchType = 'main') {
+function validateDependencies(targetBranchType = 'main', excludePackages = new Set()) {
     return new Promise((resolve) => {
         const packageJson = require(packageJsonPath);
         
@@ -38,6 +39,11 @@ function validateDependencies(targetBranchType = 'main') {
         const invalidDeps = [];
         
         for (const [dep, version] of Object.entries(dependencies)) {
+            // Skip validation for excluded packages
+            if (excludePackages.has(dep)) {
+                continue;
+            }
+            
             if (typeof version === 'string') {
                 if (!isVersionAllowed(version, targetBranchType)) {
                     invalidDeps.push(`${dep}@${version}`);


### PR DESCRIPTION
Some package (like @mui/lab) follow eternal alpha versioning policy. Need to be able to skip version validation for such packages during release-finish/hotfix-finish.